### PR TITLE
Adds warning message when deterministic training loss stagnates too quickly in partial BNNs

### DIFF
--- a/neurobayes/flax_nets/deterministic_nn.py
+++ b/neurobayes/flax_nets/deterministic_nn.py
@@ -118,7 +118,6 @@ class DeterministicNN:
                 pbar.set_postfix_str(f"Epoch {epoch+1}/{epochs}, Avg Loss: {avg_epoch_loss:.4f}")
                 pbar.update(1)
         timestr = time.strftime("%Y%m%d-%H%M%S")
-        np.savez(f'avg_epoch_losses_{timestr}.npz', loss=avg_epoch_losses)
         if self.params_history:  # Ensure there is something to average
             self.state = self.state.replace(params=self.average_params())
 

--- a/neurobayes/flax_nets/deterministic_nn.py
+++ b/neurobayes/flax_nets/deterministic_nn.py
@@ -6,8 +6,10 @@ from flax.training import train_state
 import optax
 from functools import partial
 from tqdm import tqdm
+import numpy as np
+import time
 
-from ..utils.utils import split_in_batches
+from ..utils.utils import split_in_batches, monitor_dnn_loss
 
 
 class TrainState(train_state.TrainState):
@@ -97,20 +99,26 @@ class DeterministicNN:
         num_batches = len(X_batches)
         
         with tqdm(total=epochs, desc="Training Progress", leave=True) as pbar:  # Progress bar tracks epochs now
+            avg_epoch_losses = np.empty(epochs) 
             for epoch in range(epochs):
                 epoch_loss = 0.0
                 for i, (X_batch, y_batch) in enumerate(zip(X_batches, y_batches)):
                     self.state, batch_loss = self.train_step(self.state, X_batch, y_batch)
                     epoch_loss += batch_loss
-
+                
                 # Start storing parameters in the last n epochs
                 if epochs - epoch <= self.average_last_n_weights:
                     self._store_params(self.state.params)
                 
                 avg_epoch_loss = epoch_loss / num_batches
+                avg_epoch_losses[epoch] = avg_epoch_loss
+                if epoch == 1:
+                    monitor_dnn_loss(avg_epoch_losses)
+
                 pbar.set_postfix_str(f"Epoch {epoch+1}/{epochs}, Avg Loss: {avg_epoch_loss:.4f}")
                 pbar.update(1)
-
+        timestr = time.strftime("%Y%m%d-%H%M%S")
+        np.savez(f'avg_epoch_losses_{timestr}.npz', loss=avg_epoch_losses)
         if self.params_history:  # Ensure there is something to average
             self.state = self.state.replace(params=self.average_params())
 

--- a/neurobayes/flax_nets/deterministic_nn.py
+++ b/neurobayes/flax_nets/deterministic_nn.py
@@ -7,7 +7,6 @@ import optax
 from functools import partial
 from tqdm import tqdm
 import numpy as np
-import time
 
 from ..utils.utils import split_in_batches, monitor_dnn_loss
 
@@ -99,7 +98,7 @@ class DeterministicNN:
         num_batches = len(X_batches)
         
         with tqdm(total=epochs, desc="Training Progress", leave=True) as pbar:  # Progress bar tracks epochs now
-            avg_epoch_losses = np.empty(epochs) 
+            avg_epoch_losses = np.zeros(epochs) 
             for epoch in range(epochs):
                 epoch_loss = 0.0
                 for i, (X_batch, y_batch) in enumerate(zip(X_batches, y_batches)):
@@ -112,12 +111,11 @@ class DeterministicNN:
                 
                 avg_epoch_loss = epoch_loss / num_batches
                 avg_epoch_losses[epoch] = avg_epoch_loss
-                if epoch == 1:
+                if epoch > 0:
                     monitor_dnn_loss(avg_epoch_losses)
 
                 pbar.set_postfix_str(f"Epoch {epoch+1}/{epochs}, Avg Loss: {avg_epoch_loss:.4f}")
                 pbar.update(1)
-        timestr = time.strftime("%Y%m%d-%H%M%S")
         if self.params_history:  # Ensure there is something to average
             self.state = self.state.replace(params=self.average_params())
 

--- a/neurobayes/utils/utils.py
+++ b/neurobayes/utils/utils.py
@@ -80,10 +80,12 @@ def split_dict(data: Dict[str, jnp.ndarray], chunk_size: int
 
     return result
 
-def monitor_dnn_loss(loss: np.ndarray) -> bool:
+def monitor_dnn_loss(loss: np.ndarray) -> None:
+    """Checks whether current change in loss is greater than a 25% decrease"""
     loss = loss[loss != 0]
-    if np.diff(loss)[-1] / loss[0] < -0.25:
-        warnings.warn('The deterministic training loss is decreasing rapidly - learning and accuracy may be improved by increasing the batch size, increasing MAP sigma, or adjusting the learning rate.', stacklevel=2)
+    if len(loss) > 1:
+      if np.diff(loss)[-1] / loss[0] < -0.25:
+          warnings.warn('The deterministic training loss is decreasing rapidly - learning and accuracy may be improved by increasing the batch size, increasing MAP sigma, or adjusting the learning rate.', stacklevel=2)
     return
 
 def mse(y_pred: jnp.ndarray, y_true: jnp.ndarray) -> jnp.ndarray:

--- a/neurobayes/utils/utils.py
+++ b/neurobayes/utils/utils.py
@@ -83,7 +83,7 @@ def split_dict(data: Dict[str, jnp.ndarray], chunk_size: int
 def monitor_dnn_loss(loss: np.ndarray) -> bool:
     loss = loss[loss != 0]
     if np.diff(loss)[-1] / loss[0] < -0.25:
-        warnings.warn('The deterministic training loss is decreasing rapidly - learning and accuracy may be improved by increasing the batch size, adjusting MAP sigma, or modifying the learning rate.')
+        warnings.warn('The deterministic training loss is decreasing rapidly - learning and accuracy may be improved by increasing the batch size, adjusting MAP sigma, or modifying the learning rate.', stacklevel=2)
     return
 
 def mse(y_pred: jnp.ndarray, y_true: jnp.ndarray) -> jnp.ndarray:

--- a/neurobayes/utils/utils.py
+++ b/neurobayes/utils/utils.py
@@ -81,7 +81,8 @@ def split_dict(data: Dict[str, jnp.ndarray], chunk_size: int
     return result
 
 def monitor_dnn_loss(loss: np.ndarray) -> bool:
-    if np.diff(loss)[0] / loss[0] < -0.25:
+    loss = loss[loss != 0]
+    if np.diff(loss)[-1] / loss[0] < -0.25:
         warnings.warn('The deterministic training loss is decreasing rapidly - learning and accuracy may be improved by increasing the batch size, adjusting MAP sigma, or modifying the learning rate.')
     return
 

--- a/neurobayes/utils/utils.py
+++ b/neurobayes/utils/utils.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 
 import numpy as np
 
+import warnings
 
 def infer_device(device_preference: str = None):
     """
@@ -79,6 +80,10 @@ def split_dict(data: Dict[str, jnp.ndarray], chunk_size: int
 
     return result
 
+def monitor_dnn_loss(loss: np.ndarray) -> bool:
+    if np.diff(loss)[0] / loss[0] < -0.25:
+        warnings.warn('The deterministic training loss is decreasing rapidly - learning and accuracy may be improved by increasing the batch size, adjusting MAP sigma, or modifying the learning rate.')
+    return
 
 def mse(y_pred: jnp.ndarray, y_true: jnp.ndarray) -> jnp.ndarray:
     """

--- a/neurobayes/utils/utils.py
+++ b/neurobayes/utils/utils.py
@@ -83,7 +83,7 @@ def split_dict(data: Dict[str, jnp.ndarray], chunk_size: int
 def monitor_dnn_loss(loss: np.ndarray) -> bool:
     loss = loss[loss != 0]
     if np.diff(loss)[-1] / loss[0] < -0.25:
-        warnings.warn('The deterministic training loss is decreasing rapidly - learning and accuracy may be improved by increasing the batch size, adjusting MAP sigma, or modifying the learning rate.', stacklevel=2)
+        warnings.warn('The deterministic training loss is decreasing rapidly - learning and accuracy may be improved by increasing the batch size, increasing MAP sigma, or adjusting the learning rate.', stacklevel=2)
     return
 
 def mse(y_pred: jnp.ndarray, y_true: jnp.ndarray) -> jnp.ndarray:


### PR DESCRIPTION
### Context
Certain deterministic NN hyperparameters may cause overfitting that manifests in the training loss initially decreasing very rapidly and stagnating early. A warning message to the user with suggested solutions would be helpful. Closes #11 

### Description
After the first epoch, the change in training loss is monitored and any time it drops more than 25% (see figure for justification of choice of 25%), a warning message is printed to the user:

`UserWarning: The deterministic training loss is decreasing rapidly - learning and accuracy may be improved by increasing the batch size, adjusting MAP sigma, or modifying the learning rate.`

![dnn_loss](https://github.com/user-attachments/assets/07a4baf6-c68a-4c99-9445-de283d585186)

### Changes in the codebase
1. Added a function called `monitor_dnn_loss` in `neurobayes/utils/utils.py` that prints warning when loss has decreased by 25% at any epoch.
2. Added a call to `monitor_dnn_loss` in `flax_nets/deterministic_nn.py` in the training loop (`DeterministicNN.train()`).